### PR TITLE
chore(ci): relocate and enhance Docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,7 @@
 name: Build & Publish Docker Image
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,61 @@
+name: Build & Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: read       
+  packages: write      
+  id-token: write      
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1. checkout code
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # 2. log in to GitHub Container Registry
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # 3. get the version from the tag
+      - name: Determine image tag
+        id: tag
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          else
+            echo "TAG=latest" >> $GITHUB_OUTPUT
+          fi
+
+      # 4. build and push Docker image
+      - name: Build and push app-frontend Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: app/app-frontend
+          file: app/app-frontend/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ steps.tag.outputs.TAG }}
+            ghcr.io/${{ github.repository }}:latest
+      
+      - name: Build and push app-service Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: app/app-service
+          file: app/app-service/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ steps.tag.outputs.TAG }}
+            ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
### What’s Changed

- **Added** a `workflow_dispatch` trigger to allow manual runs from the Actions UI on any branch.
- **Updated** push triggers to:
  - Run on `push` to `main`
  - Run on `push` of tags matching `v*.*.*`
- **Implemented** automatic version tagging:
  - When building on a Git tag (e.g. `v1.2.3`), the Docker image is tagged with that version.
  - Otherwise, defaults to `latest`.

### Why

- Ensures the workflow shows up in the Actions sidebar (even before merging to `main`).
- Enables easy manual testing on feature branches.
- Automates semantic versioning of container images based on Git tags.

### How to Test

1. Push this branch and confirm the workflow appears under **Actions → Build & Publish Docker Image**.
2. In the Actions UI, select **Run workflow**, choose this branch, and verify it completes.
3. Tag this branch with `vX.Y.Z` and push; check that a `vX.Y.Z`–tagged image is published.
4. Push to `main` and ensure an image tagged `latest` is published.
